### PR TITLE
feat(config): split OAuth vs API-key in models[] registry

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,54 @@
 name: Claude Code Agent
-description: General-purpose Claude Code workspace
+description: >-
+  General-purpose Claude Code workspace. Supports two auth paths:
+  (1) Claude Code subscription via OAuth token (CLAUDE_CODE_OAUTH_TOKEN,
+  obtained from `claude login`), or (2) Anthropic API key
+  (ANTHROPIC_API_KEY, pay-as-you-go via console.anthropic.com). The
+  `claude` CLI picks whichever is set; OAuth takes precedence when both
+  are present.
 version: 1.0.0
 tier: 2
 
 runtime: claude-code
 runtime_config:
   model: sonnet
+
+  # Canvas surfaces this list as a Model dropdown and auto-populates
+  # Required Env Vars based on the selected entry. OAuth and API-key
+  # variants of each model appear as separate entries so users pick
+  # the auth path matching the key they have — the claude CLI accepts
+  # either and the model id is identical across both.
+  models:
+    # --- OAuth (Claude Code subscription) — set CLAUDE_CODE_OAUTH_TOKEN ---
+    - id: sonnet
+      name: Claude Sonnet (OAuth / Claude Code subscription)
+      required_env: [CLAUDE_CODE_OAUTH_TOKEN]
+    - id: opus
+      name: Claude Opus (OAuth / Claude Code subscription)
+      required_env: [CLAUDE_CODE_OAUTH_TOKEN]
+    - id: haiku
+      name: Claude Haiku (OAuth / Claude Code subscription)
+      required_env: [CLAUDE_CODE_OAUTH_TOKEN]
+
+    # --- Direct Anthropic API — set ANTHROPIC_API_KEY ---
+    # Explicit versioned ids so the API call lands on a specific snapshot
+    # (OAuth aliases above resolve to the latest each model family).
+    - id: claude-sonnet-4-6
+      name: Claude Sonnet 4.6 (API key / Anthropic Console)
+      required_env: [ANTHROPIC_API_KEY]
+    - id: claude-opus-4-7
+      name: Claude Opus 4.7 (API key / Anthropic Console)
+      required_env: [ANTHROPIC_API_KEY]
+    - id: claude-haiku-4-5
+      name: Claude Haiku 4.5 (API key / Anthropic Console)
+      required_env: [ANTHROPIC_API_KEY]
+
+  # Default required_env — per-model entries above override this once a
+  # model is picked. Keep CLAUDE_CODE_OAUTH_TOKEN as the default so
+  # existing workspaces (which all use OAuth) keep working unchanged.
   required_env:
     - CLAUDE_CODE_OAUTH_TOKEN
+
   timeout: 0
 
 template_schema_version: 1


### PR DESCRIPTION
## Summary
Claude Code supports two auth methods that use different env vars, and the template was only exposing one of them:

| Path | Env var | Source |
|---|---|---|
| OAuth | \`CLAUDE_CODE_OAUTH_TOKEN\` | \`claude login\` — Claude Code subscription |
| API key | \`ANTHROPIC_API_KEY\` | console.anthropic.com — pay-as-you-go |

Canvas (post-molecule-core#1526) reads \`runtime_config.models\` to populate the Model dropdown and suggest Required Env Vars. Before this PR, API-key users had to manually override \`required_env\` because the template never mentioned \`ANTHROPIC_API_KEY\`.

## What changed
\`runtime_config.models\` now declares 6 entries — 3 OAuth (sonnet/opus/haiku CLI aliases) + 3 API-key (versioned \`claude-sonnet-4-6\` etc.). The dropdown labels make the auth path explicit so users pick the one matching the credential they have.

## Backward compatibility
- Top-level \`required_env\` kept as \`[CLAUDE_CODE_OAUTH_TOKEN]\` so existing workspaces unchanged
- \`claude\` CLI accepts either auth transparently; OAuth wins when both are set
- Older platform builds ignore the new \`models:\` key entirely

## Paired PR
- Molecule-AI/molecule-core#1526 — platform + canvas
- Molecule-AI/molecule-ai-workspace-template-hermes#4 — same schema change for Hermes

## Test
- [ ] After core#1526 + rebuild, open a Claude Code workspace Config tab
- [ ] Model dropdown shows 6 entries labelled with auth path
- [ ] Selecting an API-key entry switches Required Env Vars to \`[ANTHROPIC_API_KEY]\`
- [ ] Selecting an OAuth entry switches Required Env Vars to \`[CLAUDE_CODE_OAUTH_TOKEN]\`
- [ ] Existing workspace with only OAuth token set continues to run