### PR TITLE
ci: publish image to GHCR via molecule-ci reusable workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,20 @@
+name: publish-image
+
+# Builds this workspace template's Dockerfile and pushes it to GHCR as
+# `ghcr.io/molecule-ai/workspace-template-<runtime>:latest` + `:sha-<7>`.
+# The heavy lifting lives in the reusable workflow in molecule-ci —
+# change it there if the publish pattern needs to evolve.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    uses: Molecule-AI/molecule-ci/.github/workflows/publish-template-image.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a one-line caller for the `publish-template-image.yml` reusable workflow in `molecule-ci`. On every push to main (and via `workflow_dispatch`), this repo now:

- Builds the Dockerfile on the self-hosted macOS arm64 runner (linux/amd64 via QEMU).
- Pushes to `ghcr.io/molecule-ai/workspace-template-<runtime>:latest` + `:sha-<7>`.
- Smoke-tests the pushed image.

Closes the gap where template changes required a per-tenant manual rebuild.

## Test plan

- [ ] This PR triggers a `publish-image` run on merge
- [ ] GHCR package appears under Molecule-AI org

🤖 Generated with [Claude Code](https://claude.com/claude-code)