### PR TITLE
fix(publish-image): drop pull_request trigger — leaks PR builds to GHCR

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -14,7 +14,12 @@ on:
     types: [runtime-published]
   push:
     branches: [main]
-  pull_request:
+  # NOTE: do NOT add `pull_request:` here. The reusable
+  # publish-template-image workflow has no PR-skip guard, so a PR
+  # trigger pushes per-PR :latest clobbers and sha-<7> tags for
+  # unmerged code to GHCR. PRs already get a Dockerfile build smoke
+  # test from the validate-workspace-template workflow (no push) —
+  # that's the right place for PR-time verification.
   workflow_dispatch:
     inputs:
       runtime_version:
@@ -35,6 +40,6 @@ jobs:
       # exact version PyPI just published. Forwarded to the reusable
       # workflow as a docker --build-arg so the cache key changes
       # per-version and pip install resolves freshly.
-      # On other events (push/PR/manual without input), this is empty
-      # and the Dockerfile's default (requirements.txt pin) applies.
+      # On other events (push to main / manual without input), this is
+      # empty and the Dockerfile's default (requirements.txt pin) applies.
       runtime_version: ${{ github.event.client_payload.runtime_version || inputs.runtime_version || '' }}


### PR DESCRIPTION
\`on: pull_request:\` was the only template repo with this trigger out of the 8 (other 7 trigger only on \`push:main\`, \`repository_dispatch\`, \`workflow_dispatch\`). The reusable \`publish-template-image\` workflow has no PR-skip guard, so the PR trigger fired every time a PR was opened or updated and pushed both:

- \`:latest\` (clobbering the production tag with unmerged code)
- \`:sha-<7>\` (a stable tag for an unmerged commit)

…to GHCR.

PR-time verification already happens via the \`validate-workspace-template\` workflow's "Docker build smoke test" step — which builds the image but does **not** push. That's the right place for PR-time verification.

Removing the trigger here aligns claude-code with the canonical 7 templates and stops the GHCR leak.

While here, updated the \`runtime_version\` comment to drop the now-stale \`/PR\` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)