### PR TITLE
fix(a2a-v1): rewrite FilePart emit using v1 protobuf Part struct

### DIFF
--- a/claude_sdk_executor.py
+++ b/claude_sdk_executor.py
@@ -586,21 +586,27 @@ class ClaudeSDKExecutor(AgentExecutor):
         # preparing its prompt while this turn's response ships. Event
         # ordering is preserved per-queue by the A2A server, so no races.
         # If the response mentions /workspace/... files, stage each and
-        # emit FileParts alongside the text so the canvas can download.
+        # emit file parts alongside the text so the canvas can download.
+        #
+        # a2a-sdk v1 uses protobuf, NOT the v0 Pydantic discriminated-union
+        # types. There is no FilePart / TextPart / FileWithUri class — Part
+        # is one struct with optional `text`, `url`, `raw`, `data`,
+        # `filename`, `media_type` fields (plus `metadata`). Set the field
+        # that matches the part's nature; leave the rest unset.
         outbound = collect_outbound_files(response_text)
         if outbound:
-            from a2a.types import FilePart, FileWithUri, Message, Part, Role, TextPart
+            from a2a.types import Message, Part, Role
             import uuid as _uuid
-            parts: list = [Part(root=TextPart(text=response_text))] if response_text else []
+            parts: list = [Part(text=response_text)] if response_text else []
             for f in outbound:
-                parts.append(Part(root=FilePart(file=FileWithUri(
-                    uri="workspace:" + f["path"],
-                    name=f["name"],
-                    mimeType=f["mime_type"],
-                ))))
+                parts.append(Part(
+                    url="workspace:" + f["path"],
+                    filename=f["name"],
+                    media_type=f["mime_type"],
+                ))
             await event_queue.enqueue_event(Message(
-                messageId=_uuid.uuid4().hex,
-                role=Role.agent,
+                message_id=_uuid.uuid4().hex,
+                role=Role.ROLE_AGENT,
                 parts=parts,
             ))
         else:


### PR DESCRIPTION
## Production-impacting bug

\`claude_sdk_executor.py\` line 592 imports \`FilePart\`, \`TextPart\`, \`FileWithUri\` from \`a2a.types\`. These v0 Pydantic discriminated-union types **do not exist in a2a-sdk v1.0.2** (the version installed in the running image — verified directly). Import fails at runtime:

\`\`\`
File "/app/claude_sdk_executor.py", line 592, in _execute_locked
    from a2a.types import FilePart, FileWithUri, Message, Part, Role, TextPart
ImportError: cannot import name 'FilePart' from 'a2a.types'
\`\`\`

**Effect**: every claude-code workspace (Design Director, UX Researcher, every coordinator in molecule-core teams) crashes on result delivery when the response includes a \`/workspace/*\` file reference. The A2A delegation loop is broken at the result-delivery step — workspaces can receive tasks but can't ship results back.

## v0 → v1 API change

a2a-sdk v1 replaced the discriminated-union part hierarchy with a **protobuf** \`Part\` struct that has optional fields:

\`\`\`
Part DESCRIPTOR fields: ['text', 'raw', 'url', 'data', 'metadata', 'filename', 'media_type']
\`\`\`

Set the field that matches the part's nature; leave the rest unset.

## Fix

| v0 (broken) | v1 (fixed) |
|---|---|
| \`from a2a.types import FilePart, FileWithUri, Message, Part, Role, TextPart\` | \`from a2a.types import Message, Part, Role\` |
| \`Part(root=TextPart(text=t))\` | \`Part(text=t)\` |
| \`Part(root=FilePart(file=FileWithUri(uri=u, name=n, mimeType=m)))\` | \`Part(url=u, filename=n, media_type=m)\` |
| \`messageId=...\` | \`message_id=...\` |
| \`Role.agent\` | \`Role.ROLE_AGENT\` |

## Test plan

- [x] \`python3 -m py_compile claude_sdk_executor.py\` clean
- [x] **Runtime construction verified against the live v1.0.2 a2a-sdk in the claude-code template image** — Message with text + file Part constructs correctly:
  \`\`\`
  message_id: 03ff9367
  role: ROLE_AGENT
  parts count: 2
  text part: hello
  file part: workspace:foo.txt foo.txt text/plain
  \`\`\`
- [ ] End-to-end: provision a claude-code workspace, send a task whose response references a \`/workspace/*\` file, confirm result lands without ImportError

## Linked

- Same migration class as the four merged PRs across other templates today (gemini-cli #10, crewai #8, openclaw #9, autogen #8 — all \`new_agent_text_message → new_text_message\`). This one is bigger because v1 also dropped the Pydantic class hierarchy entirely.
- molecule-core memory \`reference_a2a_sdk_v0_to_v1_migration\` documents the symbol renames; this PR's fix demonstrates the **structural** change too (Pydantic → protobuf, snake_case fields).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>