### PR TITLE
fix: Token Plan URL support and multi-endpoint routing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ github://Molecule-AI/template-claude-code-default
 |---|---|---|
 | OAuth (Claude Code subscription) | `CLAUDE_CODE_OAUTH_TOKEN` | `claude login` |
 | Anthropic API (direct) | `ANTHROPIC_API_KEY` | console.anthropic.com |
-| Third-party Anthropic-compat (e.g. Xiaomi MiMo) | `ANTHROPIC_API_KEY` (provider's key) | provider console |
+| Third-party Anthropic-compat (e.g. Xiaomi MiMo pay-as-you-go) | `ANTHROPIC_API_KEY` (provider's key) | provider console |
+| Xiaomi MiMo Token Plan | `ANTHROPIC_API_KEY` (Token Plan key), `ANTHROPIC_BASE_URL` (Token Plan endpoint) | token-plan dashboard |
 
-For third-party providers, `entrypoint.sh` rewrites `ANTHROPIC_BASE_URL` based on the selected `MODEL` so the `claude` CLI routes there. Currently auto-routes `mimo-*` models to `https://api.xiaomimimo.com/anthropic`. Operator-set `ANTHROPIC_BASE_URL` is never overridden.
+For third-party providers, `entrypoint.sh` rewrites `ANTHROPIC_BASE_URL` based on the selected `MODEL` so the `claude` CLI routes there. Currently auto-routes `mimo-*` models to `https://api.xiaomimimo.com/anthropic` (pay-as-you-go). **Token Plan users** should set `ANTHROPIC_BASE_URL=https://token-plan-sgp.xiaomimimo.com/anthropic` as a workspace or org-level secret — the shell mapping is the fallback and operator-set values always win. Other Token Plan endpoints (e.g. `token-plan-hk.xiaomimimo.com`) can be used by setting the secret explicitly.
 
 ## Schema version
 `template_schema_version: 1` — compatible with Molecule AI platform v1.x.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,8 +88,16 @@ fi
 # is the third-party provider key, not an Anthropic Console key.
 #
 # Refuses to clobber an operator-set ANTHROPIC_BASE_URL — if the user
-# provided one explicitly via secrets, that wins. The mapping below is
-# only the fallback for known model prefixes.
+# provided one explicitly via secrets (e.g. a Xiaomi MiMo Token Plan
+# endpoint such as https://token-plan-sgp.xiaomimimo.com/anthropic),
+# that wins. The mapping below is only the fallback for known model
+# prefixes.
+#
+# Supported Xiaomi MiMo endpoints:
+#   - Pay-as-you-go: https://api.xiaomimimo.com/anthropic
+#   - Token Plan SG:  https://token-plan-sgp.xiaomimimo.com/anthropic
+#   - Token Plan HK:   https://token-plan-hk.xiaomimimo.com/anthropic
+# (Set ANTHROPIC_BASE_URL explicitly to use a specific endpoint.)
 #
 # Long-term this should move to a data-driven `runtime_env` field in
 # config.yaml read by the platform provisioner; tracked separately.


### PR DESCRIPTION
## Summary

Adds Token Plan documentation and multi-endpoint routing clarity to the Xiaomi MiMo auth path.

### README.md changes
- Split the single "Third-party Anthropic-compat" row into two:
  - Xiaomi MiMo **pay-as-you-go** (uses shell mapping fallback to `api.xiaomimimo.com`)
  - Xiaomi MiMo **Token Plan** (requires explicit `ANTHROPIC_BASE_URL` secret)
- Explicitly documents that operator-set `ANTHROPIC_BASE_URL` always wins over the shell mapping
- Lists the Token Plan SG and HK endpoints as examples

### entrypoint.sh changes
- Adds supported Xiaomi MiMo endpoints comment listing pay-as-you-go + Token Plan SG/HK URLs

## Motivation

PR #17 shell mapping hardcodes `https://api.xiaomimimo.com/anthropic` (pay-as-you-go). Token Plan users need `https://token-plan-sgp.xiaomimimo.com/anthropic`. The fix documents that setting `ANTHROPIC_BASE_URL` as a secret wins over the mapping — no code change needed.

## Testing

Docs/comments only — no functional change.

## Related

- Blocks: onboarding of Xiaomi MiMo Token Plan users
