### PR TITLE
fix(entrypoint): pre-create /workspace/.molecule/chat-uploads

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,17 @@ if [ "$(id -u)" = "0" ]; then
         if [ -n "$first_entry" ] && [ "$(stat -c '%u' "$first_entry" 2>/dev/null)" = "0" ]; then
             chown -R agent:agent /workspace 2>/dev/null
         fi
+        # Pre-create /workspace/.molecule/chat-uploads so the upload
+        # handler in workspace/internal_chat_uploads.py never has to
+        # mkdir as agent inside a root-owned tree. Without this the
+        # first upload after a fresh provision fails with "failed to
+        # prepare uploads dir" because the volume mount comes up with
+        # root-owned `.molecule` whenever a sibling subsystem (e.g. an
+        # adapter writing telemetry, or a workspace runtime that ran
+        # before the chown landed) raced ahead. Idempotent: a re-run
+        # finds the dir already there, mode 0755 / agent:agent.
+        mkdir -p /workspace/.molecule/chat-uploads 2>/dev/null || true
+        chown -R agent:agent /workspace/.molecule 2>/dev/null || true
     fi
     # Claude Code session directory — mounted at /root/.claude/sessions by
     # the platform provisioner. Symlink it into agent's home so the SDK


### PR DESCRIPTION
## Symptom

Fresh-tenant signup hits **\"Upload failed: failed to prepare uploads dir\"** on the first chat attachment. Reported on \`hongming.moleculesai.app\` 2026-05-01T18:30Z.

## Root cause

\`workspace/internal_chat_uploads.py:171\` runs:

\`\`\`python
Path(\"/workspace/.molecule/chat-uploads\").mkdir(parents=True, exist_ok=True)
\`\`\`

This runs as the **agent** user (uid 1000) inside the workspace runtime. The Docker named volume mounted at \`/workspace\` surfaces with root-owned subtrees in race windows (volume-cache + new-mount + RW-remount during reboot/redeploy), so \`mkdir\` for an unowned subdir of \`/workspace\` fails with EACCES.

## Fix

Pre-create \`/workspace/.molecule/chat-uploads\` as **root** in the entrypoint, BEFORE \`gosu\` drops to agent. The upload handler's \`mkdir(...exist_ok=True)\` then becomes a no-op on the common path and the failure mode it currently surfaces no longer exists.

## Why entrypoint, not the handler

- Handler-side workaround (e.g. trying \`os.umask\` or \`chmod\` from agent) cannot fix root-owned ancestor dirs.
- Entrypoint runs as root, has the privilege, fires once at boot.
- Idempotent: works on fresh volumes (creates) and reused volumes (no-op + chown re-asserts ownership).

## Test plan

- [x] \`bash -n entrypoint.sh\` clean
- [ ] Once shipped, fresh tenant provision → upload chat attachment → no 500
- [ ] Existing tenant reboot → chown re-asserts → no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)