### PR TITLE
fix(adapter): keep setup() routing — strip prefix only at CLI invocation

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -311,7 +311,14 @@ class ClaudeCodeAdapter(BaseAdapter):
             picked_model = rc.get("model") or "sonnet"
         else:
             picked_model = getattr(rc, "model", None) or "sonnet"
-        picked_model = _strip_provider_prefix(picked_model)
+        # NOTE: do NOT strip the provider prefix here. The pre-fix routing
+        # behavior — `anthropic:claude-opus-4-7` falls through to
+        # providers[0] (anthropic-oauth) when no model_prefixes match — is
+        # actually correct for OAuth users (the realistic case for the
+        # wheel default). Stripping in setup() routes OAuth users into
+        # `anthropic-api` provider and the CLI then hangs at `initialize`
+        # because ANTHROPIC_API_KEY isn't set. The strip belongs only at
+        # the CLI invocation site (create_executor below).
         provider = _resolve_provider(picked_model, providers)
         auth_env_options = provider["auth_env"]
 

--- a/tests/test_adapter_prevalidate.py
+++ b/tests/test_adapter_prevalidate.py
@@ -877,18 +877,28 @@ async def test_create_executor_strips_anthropic_prefix_dataclass(
 
 
 @pytest.mark.asyncio
-async def test_setup_strip_routes_prefixed_anthropic_to_anthropic_api(
+async def test_setup_keeps_prefix_routing_oauth_for_anthropic_prefix(
     adapter, monkeypatch, configs_dir, caplog
 ):
-    """With the prefix intact, `anthropic:claude-opus-4-7` doesn't match
-    anthropic-api's model_prefixes=("claude-",) and falls back to
-    anthropic-oauth — wrong for users on ANTHROPIC_API_KEY. The strip in
-    setup() must run BEFORE _resolve_provider so routing sees the bare id.
+    """The wheel default `anthropic:claude-opus-4-7` paired with an OAuth
+    workspace (CLAUDE_CODE_OAUTH_TOKEN set, no ANTHROPIC_API_KEY) is the
+    realistic production shape. setup() must NOT strip the prefix — doing
+    so makes `_resolve_provider` match anthropic-api's `claude-` prefix
+    and route the user away from oauth, after which the CLI hangs at
+    `initialize` because no API key is set. Caught live on workspace
+    dd40faf8 on 2026-05-01: the first prefix-strip pass in setup()
+    routed banner to `provider=anthropic-api`, OAuth user wedged.
+
+    Pin: leave routing untouched. The strip lives only in
+    create_executor() so the CLI gets a bare id. _resolve_provider's
+    fallback (providers[0] = anthropic-oauth) correctly serves the
+    OAuth + wheel-default combo.
     """
     import logging
 
     monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oat-test")
     cfg = _StubAdapterConfig(
         runtime_config={"model": "anthropic:claude-opus-4-7"},
         config_path=configs_dir,
@@ -902,6 +912,14 @@ async def test_setup_strip_routes_prefixed_anthropic_to_anthropic_api(
          if "Claude Code adapter starting" in r.getMessage()),
         "",
     )
-    assert "provider=anthropic-api" in banner, (
-        f"Expected provider=anthropic-api after stripping prefix; banner={banner!r}"
+    assert "provider=anthropic-oauth" in banner, (
+        f"Prefixed model with OAuth env must keep oauth routing; banner={banner!r}"
+    )
+    # And the no-API-key warning must NOT fire (OAuth env satisfies oauth).
+    auth_warnings = [
+        r.getMessage() for r in caplog.records
+        if "AuthenticationError" in r.getMessage()
+    ]
+    assert not auth_warnings, (
+        f"OAuth users should not see API-key warnings; got {auth_warnings}"
     )


### PR DESCRIPTION
## Summary

Live-test on workspace \`dd40faf8\` revealed PR #24's setup() strip introduced a routing regression: the wheel-default \`anthropic:claude-opus-4-7\` paired with an OAuth workspace (\`CLAUDE_CODE_OAUTH_TOKEN\` set, no \`ANTHROPIC_API_KEY\`) — the realistic production shape — got routed into the \`anthropic-api\` provider entry, after which the CLI hung at \`initialize\` because no API key env was set. Banner went \`provider=anthropic-api\`, A2A wedged on Control request timeout.

The pre-fix routing (let prefixed strings fall through to \`providers[0] = anthropic-oauth\`) is actually correct for this combo. Strip belongs only at the CLI invocation site (\`create_executor\`) where claude's \`--model\` arg must be a bare id.

## Test plan

- [x] Replaced \`test_setup_strip_routes_prefixed_anthropic_to_anthropic_api\` (which pinned the wrong assertion) with \`test_setup_keeps_prefix_routing_oauth_for_anthropic_prefix\`, pinning the inverse: prefixed model + OAuth env stays on oauth and emits no API-key warning.
- [x] All 5 unit cases on \`_strip_provider_prefix\` and \`create_executor\` strip pins from PR #24 unchanged. 36/36 pass.
- [ ] Live verify on \`dd40faf8\` — adapter live-patched on the EC2; \`Control request timeout\` is now a *different* bug (SDK \`initialize\` hang in stream-json + bypassPermissions + extra_args combination). Investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)